### PR TITLE
Update jqueryCookieGuard.js, do not show if navigator.CookiesOK is set

### DIFF
--- a/jqueryCookieGuard.js
+++ b/jqueryCookieGuard.js
@@ -202,7 +202,7 @@
                 }
 
                 if (!cookieFound)
-                    if (allCookies[i].indexOf($.cookieguard.settings.cookiePrefix) === 0)
+                    if (allCookies[i].indexOf($.cookieguard.settings.cookiePrefix) === 0 || navigator.CookiesOK)
                         cookieFound = true;
 
                 if (!cookieFound) {


### PR DESCRIPTION
If the user has installed CookiesOK to automatically accept all cookies navigator.CookiesOK will be set and the dialog should not be shown.
